### PR TITLE
Support for more complex URLs

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "postmerge": "npm install"
   },
   "dependencies": {
-    "lodash": "^3.10.1"
+    "lodash": "^3.10.1",
+    "qs": "^4.0.0"
   },
   "devDependencies": {
     "babel": "^5.8.21",

--- a/src/urlTransform.js
+++ b/src/urlTransform.js
@@ -1,7 +1,26 @@
 "use strict";
 import reduce from "lodash/collection/reduce";
+import qs from "qs";
 
 export default function urlTransform(url, params={}) {
-  return reduce(params,
-    (url, value, key)=> url.replace(new RegExp(`:${key}`, "g"), value), url);
+  var urlWithParams = reduce(params,
+    (url, value, key) => {
+      url = url.replace(new RegExp(`\\(:${key}\\)`, "g"), function() {
+        delete params[key];
+        return value;
+      });
+      url = url.replace(new RegExp(`:${key}`, "g"), function() {
+        delete params[key];
+        return value;
+      });
+      return url;
+    }, url);
+  if (!urlWithParams) return urlWithParams;
+  var cleanURL = urlWithParams.replace(new RegExp(`\\(:(.*?)\\)`, "g"), "");
+
+  var finalURL = cleanURL;
+  if (Object.keys(params).length > 0) {
+    finalURL = `${cleanURL}?${qs.stringify(params)}`;
+  }
+  return finalURL;
 }

--- a/test/urlTransform_spec.js
+++ b/test/urlTransform_spec.js
@@ -13,6 +13,13 @@ describe("urlTransform", function() {
   it("check replace path", function() {
     expect(urlTransform("/test/:id", {id: 1})).to.eql("/test/1");
     expect(urlTransform("/test/:id/hey/:id", {id: 1})).to.eql("/test/1/hey/1");
-    expect(urlTransform("/test/:id", {id1: 1})).to.eql("/test/:id");
+  });
+  it("check optional params path", function() {
+    expect(urlTransform("/test/:id", {id: 1})).to.eql("/test/1");
+    expect(urlTransform("/test/(:id)", {id: 1})).to.eql("/test/1");
+    expect(urlTransform("/test/(:id)")).to.eql("/test/");
+  });
+  it("chech non-pretty params in path", function() {
+    expect(urlTransform("/test/(:id)", {id1: 1})).to.eql("/test/?id1=1");
   });
 });


### PR DESCRIPTION
Added support for optional params using the same syntax used in react-router.
Also added support for query params for non-clean URLs.

My Regex skills are not the best, so I am more then open to feedback on that :) 

Tests also added in this PR for the new features.