### PR TITLE
change init() reference to use() in example on README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -482,7 +482,7 @@ export default reduxApi({
       }
     }
   }
-}).init(adapterFetch(fetch)); // it's nessasary to point using rest backend
+}).use("fetch", adapterFetch(fetch)); // it's nessasary to point using rest backend
 ```
 
 index.jsx


### PR DESCRIPTION
`init()` is deprecated in favour of `use()`