### PR TITLE
update example to reflect the expected proptypes

### DIFF
--- a/README.md
+++ b/README.md
@@ -500,8 +500,16 @@ const store = createStoreWithMiddleware(reducer);
 @connect((state)=> ({ entry: state.entry, regions: state.regions }))
 class Application {
   static propTypes = {
-    entry: PropTypes.object.isRequired,
-    regions: PropTypes.array.isRequired,
+    entry: PropTypes.shape({
+      loading: PropTypes.bool.isRequired,
+      data: PropTypes.shape({
+        text: PropTypes.string
+      }).isRequired
+    }).isRequired,
+    regions: PropTypes.shape({
+      loading: PropTypes.bool.isRequired,
+      data: PropTypes.array.isRequired
+    }).isRequired,
     dispatch: PropTypes.func.isRequired
   }
   componentDidMount() {


### PR DESCRIPTION
The example was erroneously expecting the `entry` and `regions` PropTypes, particularly when it comes to the `regions`, this PR makes it a little more clear of what props to expect.