### PR TITLE
Add: expose requestOptions in prefetch functions

### DIFF
--- a/docs/DOCS.md
+++ b/docs/DOCS.md
@@ -241,10 +241,25 @@ In this case you global state is look like this:
       }
     ],
     options: function(url, params, getState) {
-      const {user: {data: {uuid}}} = getState();
+      const {profile: {data: {uuid}}} = getState();
       return { ...params, body: { ...params.body, uuid }};
     }
-  }
+  },
+  friends: {
+    url: "/user/:name/friends",
+    prefetch: [
+      function({actions, dispatch, getState, requestOptions}, cb) {
+        const {profile: {data: {uuid}}} = getState();
+        const {pathVars: {name}} = requestOptions;
+        uuid ? cb() : dispatch(actions.profile({name}, cb));
+      }
+      ,
+      options: function(url, params, getState) {
+        const {profile: {data: {uuid}}} = getState();
+        return { ...params, body: { ...params.body, uuid }};
+      }
+    ]
+  }  
 }
 ```
 

--- a/src/actionFn.js
+++ b/src/actionFn.js
@@ -130,6 +130,7 @@ export default function actionFn(url, name, options, ACTIONS={}, meta={}) {
       const fetchResolverOpts = {
         dispatch,
         getState,
+        requestOptions,
         actions: meta.actions,
         prefetch: meta.prefetch
       };

--- a/test/actionFn_spec.js
+++ b/test/actionFn_spec.js
@@ -430,17 +430,18 @@ describe("actionFn", function() {
         }
       ]
     };
+    const requestOptions = { pathvars: undefined, params: {} };
     const api = actionFn("/test/:id", "test", null, ACTIONS, meta);
     const expectedEvent = [{
       type: ACTIONS.actionFetch,
       syncing: false,
-      request: { pathvars: undefined, params: {} }
+      request: requestOptions
     }, {
       type: ACTIONS.actionSuccess,
       data: { msg: "hello" },
       origData: { msg: "hello" },
       syncing: false,
-      request: { pathvars: undefined, params: {} }
+      request: requestOptions
     }];
     function dispatch(msg) {
       expect(expectedEvent).to.have.length.above(0);
@@ -448,7 +449,7 @@ describe("actionFn", function() {
       expect(msg).to.eql(exp);
     }
     const expOpts = {
-      dispatch, getState, actions: undefined, prefetch: meta.prefetch
+      dispatch, getState, requestOptions, actions: undefined, prefetch: meta.prefetch
     };
     return new Promise((resolve)=> {
       api(resolve)(dispatch, getState);


### PR DESCRIPTION
You may need `requestOptions` object to do some smart stuff in your prefetch functions.
