### PR TITLE
Configuration: `responseHandler`: allow modify error or response

### DIFF
--- a/docs/DOCS.md
+++ b/docs/DOCS.md
@@ -490,12 +490,12 @@ reduxApi({ ... }).use("responseHandler",
 ```js
 reduxApi({ ... }).use("responseHandler",
   (err, data)=> {
-    if (err.message = 'Not allowed') {
-      throw new NotAllowedErro()
+    if (err.message === 'Not allowed') {
+      throw new NotAllowedError();
     } else {
-      return data
+      return data;
     }
-  }
+  });
 ```
 
 ####init(adapter, isServer, rootUrl)

--- a/docs/DOCS.md
+++ b/docs/DOCS.md
@@ -480,12 +480,22 @@ reduxApi({ ... }).use("middlewareParser",
 ```
 
 ####responseHandler
-- @description - catch all http response from each redux-api endpoint. First argument is Error is response fail, second argument data from success response.
+- @description - catch all http response from each redux-api endpoint. First argument is Error is response fail, second argument data from success response. It can be used for logging, error handling or data transformation.
 - @example
 ```js
 reduxApi({ ... }).use("responseHandler",
   (err, data)=>
     err ? console.log("ERROR", err) : console.log("SUCCESS", data));
+```
+```js
+reduxApi({ ... }).use("responseHandler",
+  (err, data)=> {
+    if (err.message = 'Not allowed') {
+      throw new NotAllowedErro()
+    } else {
+      return data
+    }
+  }
 ```
 
 ####init(adapter, isServer, rootUrl)

--- a/src/actionFn.js
+++ b/src/actionFn.js
@@ -91,15 +91,21 @@ export default function actionFn(url, name, options, ACTIONS={}, meta={}) {
           err=> err ? reject(err) : resolve(data))));
     if (responseHandler) {
       if (result && result.then) {
-        result.then(
-          data=> responseHandler(null, data),
+        return result.then(
+          (data)=> {
+            const res = responseHandler(null, data);
+            if (res === undefined) {
+              return data;
+            } else {
+              return res;
+            }
+          },
           err=> responseHandler(err)
         );
       } else {
-        responseHandler(result);
+        return responseHandler(result);
       }
     }
-    result && result.catch && result.catch(none);
     return result;
   };
 


### PR DESCRIPTION
Backward compatibility is not broken: if the `responseHandler` return explicitly `undefined`, we return the data.