### PR TITLE
utils: get: allow `array` as path name

### DIFF
--- a/src/utils/get.js
+++ b/src/utils/get.js
@@ -5,8 +5,13 @@ function isEmpty(name) {
   return name === "" || name === null || name === (void 0);
 }
 
-export default function (obj, ...path) {
+function get (obj, ...path) {
   return path.reduce(
-    (memo, name)=> isEmpty(name) ? memo : (memo && memo[name])
+    (memo, name)=>
+      Array.isArray(name)
+        ? get(memo, ...name)
+        : isEmpty(name) ? memo : (memo && memo[name])
   , obj);
 }
+
+export default get;

--- a/test/get_spec.js
+++ b/test/get_spec.js
@@ -30,4 +30,20 @@ describe("get", function() {
     const c = get(obj, "c", "b", "a");
     expect(c).to.not.exist;
   });
+
+  it("check `get` array path", function() {
+    const obj = {
+      a: { b: { c: 2 } }
+    };
+    const c = get(obj, ["a", "b"], "c");
+    expect(c).to.eql(2);
+  });
+
+  it("check `get` array incorrect path", function() {
+    const obj = {
+      a: { b: { c: 2 } }
+    };
+    const c = get(obj, ["c", "b"], "a");
+    expect(c).to.not.exist;
+  });
 });


### PR DESCRIPTION
It will allow to specify an array to the `prefix` base option. Useful when the `redux-api` resource is not on the root of the state. Ex:
```js
reduxApi({
  // …
}, {
  prefix: [‘api, ‘someResource’]
})
```