### PR TITLE
Fix for concurrent action calls

### DIFF
--- a/src/actionFn.js
+++ b/src/actionFn.js
@@ -22,7 +22,6 @@ import { getCacheManager } from "./utils/cache";
  */
 export default function actionFn(url, name, options, ACTIONS={}, meta={}) {
   const { actionFetch, actionSuccess, actionFail, actionReset, actionCache } = ACTIONS;
-  const pubsub = new PubSub();
   const requestHolder = createHolder();
 
   function getOptions(urlT, params, getState) {
@@ -122,6 +121,7 @@ export default function actionFn(url, name, options, ACTIONS={}, meta={}) {
   function fn(...args) {
     const [pathvars, params, callback] = extractArgs(args);
     const syncing = params ? !!params.syncing : false;
+    const pubsub = new PubSub();
     params && delete params.syncing;
     pubsub.push(callback);
     return (...middlewareArgs)=> {


### PR DESCRIPTION
If multiple actions are called to the same endpoint in rapid succession, all the callbacks are pushed onto the same pubsub object. When the first fetch returns, all of the callbacks are called with that data, and subsequent fetch returns call no callbacks. Moving the pubsub instantiation into the individual calls to the api solves this issue.