### PR TITLE
Support multiple optional url params

### DIFF
--- a/src/urlTransform.js
+++ b/src/urlTransform.js
@@ -34,8 +34,8 @@ export default function urlTransform(url, params, options) {
   if (!urlWithParams) { return urlWithParams; }
   const { protocol, host, path } = parse(urlWithParams);
   const cleanURL = (host) ?
-    `${protocol}//${host}${path.replace(rxClean, "")}` :
-    path.replace(rxClean, "");
+    `${protocol}//${host}${path.replace(rxClean, "").replace(/\/+/g, '/')}` :
+    path.replace(rxClean, "").replace(/\/+/g, '/');
   const usedKeysArray = Object.keys(usedKeys);
   if (usedKeysArray.length !== Object.keys(params).length) {
     const urlObject = cleanURL.split("?");
@@ -58,5 +58,5 @@ export default function urlTransform(url, params, options) {
     const urlStringParams = qs.stringify(mergeParams, qsStringifyOptions);
     return `${urlObject[0]}?${urlStringParams}`;
   }
-  return cleanURL.replace(/\/+/, "/");
+  return cleanURL;
 }

--- a/src/urlTransform.js
+++ b/src/urlTransform.js
@@ -58,5 +58,5 @@ export default function urlTransform(url, params, options) {
     const urlStringParams = qs.stringify(mergeParams, qsStringifyOptions);
     return `${urlObject[0]}?${urlStringParams}`;
   }
-  return cleanURL;
+  return cleanURL.replace(/\/+/, '/');
 }

--- a/src/urlTransform.js
+++ b/src/urlTransform.js
@@ -34,8 +34,8 @@ export default function urlTransform(url, params, options) {
   if (!urlWithParams) { return urlWithParams; }
   const { protocol, host, path } = parse(urlWithParams);
   const cleanURL = (host) ?
-    `${protocol}//${host}${path.replace(rxClean, "").replace(/\/+/g, '/')}` :
-    path.replace(rxClean, "").replace(/\/+/g, '/');
+    `${protocol}//${host}${path.replace(rxClean, "").replace(/\/+/g, "/")}` :
+    path.replace(rxClean, "").replace(/\/+/g, "/");
   const usedKeysArray = Object.keys(usedKeys);
   if (usedKeysArray.length !== Object.keys(params).length) {
     const urlObject = cleanURL.split("?");

--- a/src/urlTransform.js
+++ b/src/urlTransform.js
@@ -58,5 +58,5 @@ export default function urlTransform(url, params, options) {
     const urlStringParams = qs.stringify(mergeParams, qsStringifyOptions);
     return `${urlObject[0]}?${urlStringParams}`;
   }
-  return cleanURL.replace(/\/+/, '/');
+  return cleanURL.replace(/\/+/, "/");
 }

--- a/test/urlTransform_spec.js
+++ b/test/urlTransform_spec.js
@@ -39,7 +39,7 @@ describe("urlTransform", function() {
 
   it("check clean params", function() {
     expect(urlTransform("/test/:id")).to.eql("/test/");
-    expect(urlTransform("/test/:id/")).to.eql("/test//");
+    expect(urlTransform("/test/:id/")).to.eql("/test/");
     expect(urlTransform("/test/(:id)")).to.eql("/test/");
   });
 


### PR DESCRIPTION
This will allow a url like `${base}/clients/:clientId/:method`
where **clientId** and **method** are both optional. 

We don't want to end up with double slashes on the sync request.