### PR TITLE
Add `pathvars` & `body` in the store

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@ bower_components
 
 #VSCode metadata
 .vscode
+
+#IntelliJ metadata
+*.iml

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "chai": "3.5.0",
     "coveralls": "2.12.0",
     "cross-env": "3.2.3",
-    "eslint": "3.17.0",
+    "eslint": "3.19.0",
     "eslint-config-airbnb": "14.1.0",
     "eslint-plugin-import": "2.2.0",
     "eslint-plugin-jsx-a11y": "4.0.0",

--- a/src/index.js
+++ b/src/index.js
@@ -142,8 +142,8 @@ export default function reduxApi(config, baseConfig) {
       const syncing = false;
       const loading = false;
       const initialState = opts.cache ?
-        { sync, syncing, loading, data, pathvars:{}, body:{}, cache: {} } :
-        { sync, syncing, loading, data, pathvars:{}, body:{} };
+        { sync, syncing, loading, data, pathvars: {}, body: {}, cache: {} } :
+        { sync, syncing, loading, data, pathvars: {}, body: {} };
 
       const reducer = opts.reducer ? opts.reducer.bind(memo) : null;
       memo.reducers[reducerName] = reducerFn(initialState, ACTIONS, reducer);

--- a/src/index.js
+++ b/src/index.js
@@ -142,8 +142,8 @@ export default function reduxApi(config, baseConfig) {
       const syncing = false;
       const loading = false;
       const initialState = opts.cache ?
-        { sync, syncing, loading, data, cache: {} } :
-        { sync, syncing, loading, data };
+        { sync, syncing, loading, data, pathvars:{}, body:{}, cache: {} } :
+        { sync, syncing, loading, data, pathvars:{}, body:{} };
 
       const reducer = opts.reducer ? opts.reducer.bind(memo) : null;
       memo.reducers[reducerName] = reducerFn(initialState, ACTIONS, reducer);

--- a/src/reducerFn.js
+++ b/src/reducerFn.js
@@ -14,12 +14,13 @@ export default function reducerFn(initialState, actions={}, reducer) {
   const { actionFetch, actionSuccess, actionFail,
     actionReset, actionCache, actionAbort } = actions;
   return (state=initialState, action)=> {
+    const params = action.params || {};
     switch (action.type) {
       case actionFetch:
         return {
           ...state,
-          pathvars:{},
-          body:{},
+          pathvars: action.pathvars || {},
+          body: params.body || {},
           loading: true,
           error: null,
           syncing: !!action.syncing
@@ -27,8 +28,6 @@ export default function reducerFn(initialState, actions={}, reducer) {
       case actionSuccess:
         return {
           ...state,
-          pathvars:{},
-          body:{},
           loading: false,
           sync: true,
           syncing: false,
@@ -38,8 +37,6 @@ export default function reducerFn(initialState, actions={}, reducer) {
       case actionFail:
         return {
           ...state,
-          pathvars:{},
-          body:{},
           loading: false,
           error: action.error,
           syncing: false
@@ -47,7 +44,10 @@ export default function reducerFn(initialState, actions={}, reducer) {
       case actionReset:
         const { mutation } = action;
         return (mutation === "sync") ?
-          { ...state, sync: false } :
+          { ...state,
+            pathvars:{},
+            body:{},
+            sync: false } :
           { ...initialState };
       case actionAbort:
         return {
@@ -64,8 +64,6 @@ export default function reducerFn(initialState, actions={}, reducer) {
         const expire = setExpire(action.expire, cacheExpire);
         return {
           ...state,
-          pathvars:{},
-          body:{},
           cache: { ...state.cache, [id]: { expire, data } }
         };
       default:

--- a/src/reducerFn.js
+++ b/src/reducerFn.js
@@ -7,7 +7,6 @@ import { setExpire } from "./utils/cache";
  * Reducer contructor
  * @param  {Object}   initialState default initial state
  * @param  {Object}   actions      actions map
- * @param  {Function} transformer  transformer function
  * @param  {Function} reducer      custom reducer function
  * @return {Function}              reducer function
  */
@@ -19,6 +18,8 @@ export default function reducerFn(initialState, actions={}, reducer) {
       case actionFetch:
         return {
           ...state,
+          pathvars:{},
+          body:{},
           loading: true,
           error: null,
           syncing: !!action.syncing
@@ -26,6 +27,8 @@ export default function reducerFn(initialState, actions={}, reducer) {
       case actionSuccess:
         return {
           ...state,
+          pathvars:{},
+          body:{},
           loading: false,
           sync: true,
           syncing: false,
@@ -35,6 +38,8 @@ export default function reducerFn(initialState, actions={}, reducer) {
       case actionFail:
         return {
           ...state,
+          pathvars:{},
+          body:{},
           loading: false,
           error: action.error,
           syncing: false
@@ -45,13 +50,22 @@ export default function reducerFn(initialState, actions={}, reducer) {
           { ...state, sync: false } :
           { ...initialState };
       case actionAbort:
-        return { ...state, loading: false, syncing: false, error: action.error };
+        return {
+          ...state,
+          pathvars:{},
+          body:{},
+          loading: false,
+          syncing: false,
+          error: action.error
+        };
       case actionCache:
         const { id, data } = action;
         const cacheExpire = state.cache[id] ? state.cache[id].expire : null;
         const expire = setExpire(action.expire, cacheExpire);
         return {
           ...state,
+          pathvars:{},
+          body:{},
           cache: { ...state.cache, [id]: { expire, data } }
         };
       default:

--- a/src/reducerFn.js
+++ b/src/reducerFn.js
@@ -44,16 +44,16 @@ export default function reducerFn(initialState, actions={}, reducer) {
       case actionReset:
         const { mutation } = action;
         return (mutation === "sync") ?
-          { ...state,
-            pathvars:{},
-            body:{},
-            sync: false } :
-          { ...initialState };
+        { ...state,
+          pathvars: {},
+          body: {},
+          sync: false } :
+        { ...initialState };
       case actionAbort:
         return {
           ...state,
-          pathvars:{},
-          body:{},
+          pathvars: {},
+          body: {},
           loading: false,
           syncing: false,
           error: action.error

--- a/test/actionFn_spec.js
+++ b/test/actionFn_spec.js
@@ -219,12 +219,12 @@ describe("actionFn", function() {
 
     const expectedEvent = [
       {
-        type: "actionFetch",
+        type: ACTIONS.actionFetch,
         syncing: true,
         request: { pathvars: undefined, params: {} }
       },
       {
-        type: "actionSuccess",
+        type: ACTIONS.actionSuccess,
         syncing: false,
         data: { msg: "hello" },
         origData: { msg: "hello" },
@@ -549,42 +549,42 @@ describe("actionFn", function() {
     };
     const api = actionFn("/test/:id", "test", null, ACTIONS, meta);
     const expectedEvent = [{
-      type: "actionFetch",
+      type: ACTIONS.actionFetch,
       syncing: false,
       request: {
         pathvars: { id: 1 },
         params: { method: "GET" }
       }
     }, {
-      type: "actionFetch",
+      type: ACTIONS.actionFetch,
       syncing: false,
       request: {
         pathvars: { id: 2 },
         params: { body: "Hello", method: "POST" }
       }
     }, {
-      type: "actionFetch",
+      type: ACTIONS.actionFetch,
       syncing: false,
       request: {
         pathvars: { id: 3 },
         params: { body: "World", method: "PUT" }
       }
     }, {
-      type: "actionFetch",
+      type: ACTIONS.actionFetch,
       syncing: false,
       request: {
         pathvars: { id: 4 },
         params: { method: "DELETE" }
       }
     }, {
-      type: "actionFetch",
+      type: ACTIONS.actionFetch,
       syncing: false,
       request: {
         pathvars: { id: 5 },
         params: { body: "World", method: "PATCH" }
       }
     }, {
-      type: "actionSuccess",
+      type: ACTIONS.actionSuccess,
       syncing: false,
       data: { url: "/test/1", opts: { method: "GET" } },
       origData: { url: "/test/1", opts: { method: "GET" } },
@@ -593,7 +593,7 @@ describe("actionFn", function() {
         params: { method: "GET" }
       }
     }, {
-      type: "actionSuccess",
+      type: ACTIONS.actionSuccess,
       syncing: false,
       data: {
         url: "/test/2",
@@ -608,7 +608,7 @@ describe("actionFn", function() {
         params: { body: "Hello", method: "POST" }
       }
     }, {
-      type: "actionSuccess",
+      type: ACTIONS.actionSuccess,
       syncing: false,
       data: {
         url: "/test/3",
@@ -623,7 +623,7 @@ describe("actionFn", function() {
         params: { body: "World", method: "PUT" }
       }
     }, {
-      type: "actionSuccess",
+      type: ACTIONS.actionSuccess,
       syncing: false,
       data: {
         url: "/test/4",
@@ -638,7 +638,7 @@ describe("actionFn", function() {
         params: { method: "DELETE" }
       }
     }, {
-      type: "actionSuccess",
+      type: ACTIONS.actionSuccess,
       syncing: false,
       data: {
         url: "/test/5",
@@ -710,11 +710,11 @@ describe("actionFn", function() {
     };
     const api = actionFn("/test/:id", "test", null, ACTIONS, meta);
     const expectedEvent = [{
-      type: "actionFetch",
+      type: ACTIONS.actionFetch,
       syncing: false,
       request: { pathvars: { id: "overwrite" }, params: undefined }
     }, {
-      type: "actionSuccess",
+      type: ACTIONS.actionSuccess,
       syncing: false,
       data: { url: "/test/overwrite", opts: null },
       origData: { url: "/test/overwrite", opts: null },
@@ -745,14 +745,14 @@ describe("actionFn", function() {
     };
     const api = actionFn("/test/", "test", null, ACTIONS, meta);
     const expectedEvent = [{
-      type: "actionFetch",
+      type: ACTIONS.actionFetch,
       syncing: false,
       request: {
         pathvars: { id: 1 },
         params: null
       }
     }, {
-      type: "actionSuccess",
+      type: ACTIONS.actionSuccess,
       syncing: false,
       data: { url: "/test/?id=1", opts: null },
       origData: { url: "/test/?id=1", opts: null },

--- a/test/reducerFn_spec.js
+++ b/test/reducerFn_spec.js
@@ -13,7 +13,7 @@ describe("reducerFn", function() {
     expect(isFunction(fn)).to.be.true;
   });
   it("check", function() {
-    const initialState = { loading: false, data: { msg: "Hello" } };
+    const initialState = { loading: false, pathvars:{}, body:{}, data: { msg: "Hello" } };
     const actions = {
       actionFetch: "actionFetch",
       actionSuccess: "actionSuccess",
@@ -25,25 +25,93 @@ describe("reducerFn", function() {
     expect(res1).to.eql({
       loading: true, error: null, data: { msg: "Hello" }, syncing: false, pathvars:{}, body:{}
     });
-
+  
     const res2 = fn(initialState, { type: actions.actionSuccess, data: true });
     expect(res2).to.eql({
       loading: false, error: null, data: true, sync: true, syncing: false, pathvars:{}, body:{}
     });
-
+    
     const res3 = fn(initialState, { type: actions.actionFail, error: "Error" });
     expect(res3).to.eql({
       loading: false, error: "Error", data: { msg: "Hello" }, syncing: false, pathvars:{}, body:{}
     });
 
     const res4 = fn(initialState, { type: actions.actionReset });
-    expect(res4).to.eql(initialState);
-    expect(res4 !== initialState).to.be.true;
+    expect(res4).to.deep.eq(initialState);
 
     const res5 = fn(undefined, { type: "fake" });
-    expect(res5 === initialState).to.be.true;
+    expect(res5).to.deep.eq(initialState);
   });
-
+  
+  it("check with path variables", function() {
+    const initialState = { loading: false, pathvars:{}, body:{}, data: { msg: "Hello" } };
+    const actions = {
+      actionFetch: "actionFetch",
+      actionSuccess: "actionSuccess",
+      actionFail: "actionFail",
+      actionReset: "actionReset"
+    };
+    const fn = reducerFn(initialState, actions);
+    
+    const res1 = fn(initialState, { type: actions.actionFetch, pathvars: { id: 42 } });
+    expect(res1).to.eql({
+      loading: true, error: null, data: { msg: "Hello" }, syncing: false, pathvars:{ id: 42 }, body:{}
+    });
+    
+    const res1c = fn(initialState, { type: actions.actionFetch, pathvars: { other: "var" }, params: { method: "post", body:{hello:"world"}} });
+    expect(res1c).to.eql({
+      loading: true, error: null, data: { msg: "Hello" }, syncing: false, pathvars:{ other: "var" }, body:{hello:"world"}
+    });
+    
+    const res2 = fn(res1, { type: actions.actionSuccess, data: true });
+    expect(res2).to.eql({
+      loading: false, error: null, data: true, sync: true, syncing: false, pathvars:{ id: 42 }, body:{}
+    });
+    
+    const res3 = fn(res1, { type: actions.actionFail, error: "Error" });
+    expect(res3).to.eql({
+      loading: false, error: "Error", data: { msg: "Hello" }, syncing: false, pathvars:{ id: 42 }, body:{}
+    });
+    
+    const res4 = fn(res2, { type: actions.actionReset });
+    expect(res4).to.deep.eq(initialState);
+    
+    const res5 = fn(undefined, { type: "fake" });
+    expect(res5).to.deep.eq(initialState);
+  });
+  
+  it("check with body", function() {
+    const initialState = { loading: false, pathvars:{}, body:{}, data: { msg: "Hello" } };
+    const actions = {
+      actionFetch: "actionFetch",
+      actionSuccess: "actionSuccess",
+      actionFail: "actionFail",
+      actionReset: "actionReset"
+    };
+    const fn = reducerFn(initialState, actions);
+    
+    const res1 = fn(initialState, { type: actions.actionFetch, pathvars: { other: "var" }, params: { method: "post", body:{hello:"world", it:{should:{store:' the body'}}}} });
+    expect(res1).to.eql({
+      loading: true, error: null, data: { msg: "Hello" }, syncing: false, pathvars:{ other: "var" }, body:{hello:"world", it:{should:{store:' the body'}}}
+    });
+    
+    const res2 = fn(res1, { type: actions.actionSuccess, data: true });
+    expect(res2).to.eql({
+      loading: false, error: null, data: true, sync: true, syncing: false, pathvars:{ other: "var" }, body:{hello:"world", it:{should:{store:' the body'}}}
+    });
+    
+    const res3 = fn(res1, { type: actions.actionFail, error: "Error" });
+    expect(res3).to.eql({
+      loading: false, error: "Error", data: { msg: "Hello" }, syncing: false, pathvars:{ other: "var" }, body:{hello:"world", it:{should:{store:' the body'}}}
+    });
+    
+    const res4 = fn(res2, { type: actions.actionReset });
+    expect(res4).to.deep.eq(initialState);
+    
+    const res5 = fn(undefined, { type: "fake" });
+    expect(res5).to.deep.eq(initialState);
+  });
+  
   it("check injected reducer", function() {
     const initialState = { loading: false, data: { msg: "Hello" } };
     const actions = {

--- a/test/reducerFn_spec.js
+++ b/test/reducerFn_spec.js
@@ -23,17 +23,17 @@ describe("reducerFn", function() {
     const fn = reducerFn(initialState, actions);
     const res1 = fn(initialState, { type: actions.actionFetch });
     expect(res1).to.eql({
-      loading: true, error: null, data: { msg: "Hello" }, syncing: false
+      loading: true, error: null, data: { msg: "Hello" }, syncing: false, pathvars:{}, body:{}
     });
 
     const res2 = fn(initialState, { type: actions.actionSuccess, data: true });
     expect(res2).to.eql({
-      loading: false, error: null, data: true, sync: true, syncing: false
+      loading: false, error: null, data: true, sync: true, syncing: false, pathvars:{}, body:{}
     });
 
     const res3 = fn(initialState, { type: actions.actionFail, error: "Error" });
     expect(res3).to.eql({
-      loading: false, error: "Error", data: { msg: "Hello" }, syncing: false
+      loading: false, error: "Error", data: { msg: "Hello" }, syncing: false, pathvars:{}, body:{}
     });
 
     const res4 = fn(initialState, { type: actions.actionReset });

--- a/test/reducerFn_spec.js
+++ b/test/reducerFn_spec.js
@@ -13,7 +13,7 @@ describe("reducerFn", function() {
     expect(isFunction(fn)).to.be.true;
   });
   it("check", function() {
-    const initialState = { loading: false, pathvars:{}, body:{}, data: { msg: "Hello" } };
+    const initialState = { loading: false, pathvars: {}, body: {}, data: { msg: "Hello" } };
     const actions = {
       actionFetch: "actionFetch",
       actionSuccess: "actionSuccess",
@@ -23,17 +23,17 @@ describe("reducerFn", function() {
     const fn = reducerFn(initialState, actions);
     const res1 = fn(initialState, { type: actions.actionFetch });
     expect(res1).to.eql({
-      loading: true, error: null, data: { msg: "Hello" }, syncing: false, pathvars:{}, body:{}
+      loading: true, error: null, data: { msg: "Hello" }, syncing: false, pathvars: {}, body: {}
     });
-  
+
     const res2 = fn(initialState, { type: actions.actionSuccess, data: true });
     expect(res2).to.eql({
-      loading: false, error: null, data: true, sync: true, syncing: false, pathvars:{}, body:{}
+      loading: false, error: null, data: true, sync: true, syncing: false, pathvars: {}, body: {}
     });
-    
+
     const res3 = fn(initialState, { type: actions.actionFail, error: "Error" });
     expect(res3).to.eql({
-      loading: false, error: "Error", data: { msg: "Hello" }, syncing: false, pathvars:{}, body:{}
+      loading: false, error: "Error", data: { msg: "Hello" }, syncing: false, pathvars: {}, body: {}
     });
 
     const res4 = fn(initialState, { type: actions.actionReset });
@@ -42,9 +42,9 @@ describe("reducerFn", function() {
     const res5 = fn(undefined, { type: "fake" });
     expect(res5).to.deep.eq(initialState);
   });
-  
+
   it("check with path variables", function() {
-    const initialState = { loading: false, pathvars:{}, body:{}, data: { msg: "Hello" } };
+    const initialState = { loading: false, pathvars: {}, body: {}, data: { msg: "Hello" } };
     const actions = {
       actionFetch: "actionFetch",
       actionSuccess: "actionSuccess",
@@ -52,36 +52,37 @@ describe("reducerFn", function() {
       actionReset: "actionReset"
     };
     const fn = reducerFn(initialState, actions);
-    
+
     const res1 = fn(initialState, { type: actions.actionFetch, pathvars: { id: 42 } });
     expect(res1).to.eql({
-      loading: true, error: null, data: { msg: "Hello" }, syncing: false, pathvars:{ id: 42 }, body:{}
+      loading: true, error: null, data: { msg: "Hello" }, syncing: false, pathvars: { id: 42 }, body: {}
     });
-    
-    const res1c = fn(initialState, { type: actions.actionFetch, pathvars: { other: "var" }, params: { method: "post", body:{hello:"world"}} });
-    expect(res1c).to.eql({
-      loading: true, error: null, data: { msg: "Hello" }, syncing: false, pathvars:{ other: "var" }, body:{hello:"world"}
-    });
-    
+
     const res2 = fn(res1, { type: actions.actionSuccess, data: true });
     expect(res2).to.eql({
-      loading: false, error: null, data: true, sync: true, syncing: false, pathvars:{ id: 42 }, body:{}
+      loading: false,
+      error: null,
+      data: true,
+      sync: true,
+      syncing: false,
+      pathvars: { id: 42 },
+      body: {}
     });
-    
+
     const res3 = fn(res1, { type: actions.actionFail, error: "Error" });
     expect(res3).to.eql({
-      loading: false, error: "Error", data: { msg: "Hello" }, syncing: false, pathvars:{ id: 42 }, body:{}
+      loading: false, error: "Error", data: { msg: "Hello" }, syncing: false, pathvars: { id: 42 }, body: {}
     });
-    
+
     const res4 = fn(res2, { type: actions.actionReset });
     expect(res4).to.deep.eq(initialState);
-    
+
     const res5 = fn(undefined, { type: "fake" });
     expect(res5).to.deep.eq(initialState);
   });
-  
+
   it("check with body", function() {
-    const initialState = { loading: false, pathvars:{}, body:{}, data: { msg: "Hello" } };
+    const initialState = { loading: false, pathvars: {}, body: {}, data: { msg: "Hello" } };
     const actions = {
       actionFetch: "actionFetch",
       actionSuccess: "actionSuccess",
@@ -89,29 +90,29 @@ describe("reducerFn", function() {
       actionReset: "actionReset"
     };
     const fn = reducerFn(initialState, actions);
-    
-    const res1 = fn(initialState, { type: actions.actionFetch, pathvars: { other: "var" }, params: { method: "post", body:{hello:"world", it:{should:{store:' the body'}}}} });
+
+    const res1 = fn(initialState, { type: actions.actionFetch, pathvars: { other: "var" }, params: { method: "post", body: { hello: "world", it: { should: { store: " the body" } } } } });
     expect(res1).to.eql({
-      loading: true, error: null, data: { msg: "Hello" }, syncing: false, pathvars:{ other: "var" }, body:{hello:"world", it:{should:{store:' the body'}}}
+      loading: true, error: null, data: { msg: "Hello" }, syncing: false, pathvars: { other: "var" }, body: { hello: "world", it: { should: { store: " the body" } } }
     });
-    
+
     const res2 = fn(res1, { type: actions.actionSuccess, data: true });
     expect(res2).to.eql({
-      loading: false, error: null, data: true, sync: true, syncing: false, pathvars:{ other: "var" }, body:{hello:"world", it:{should:{store:' the body'}}}
+      loading: false, error: null, data: true, sync: true, syncing: false, pathvars: { other: "var" }, body: { hello: "world", it: { should: { store: " the body" } } }
     });
-    
+
     const res3 = fn(res1, { type: actions.actionFail, error: "Error" });
     expect(res3).to.eql({
-      loading: false, error: "Error", data: { msg: "Hello" }, syncing: false, pathvars:{ other: "var" }, body:{hello:"world", it:{should:{store:' the body'}}}
+      loading: false, error: "Error", data: { msg: "Hello" }, syncing: false, pathvars: { other: "var" }, body: { hello: "world", it: { should: { store: " the body" } } }
     });
-    
+
     const res4 = fn(res2, { type: actions.actionReset });
     expect(res4).to.deep.eq(initialState);
-    
+
     const res5 = fn(undefined, { type: "fake" });
     expect(res5).to.deep.eq(initialState);
   });
-  
+
   it("check injected reducer", function() {
     const initialState = { loading: false, data: { msg: "Hello" } };
     const actions = {

--- a/test/redux_spec.js
+++ b/test/redux_spec.js
@@ -153,8 +153,8 @@ describe("redux", ()=> {
           sync: false,
           syncing: false,
           loading: false,
-          pathvars:{},
-          body:{},
+          pathvars: {},
+          body: {},
           data: {},
           error: new Error("Error: Application abort request")
         });
@@ -167,23 +167,23 @@ describe("redux", ()=> {
     store = createStoreWithMiddleware(reducer);
 
     expect(store.getState().test).to.eql(
-      { sync: false, syncing: false, loading: false, pathvars:{}, body:{}, data: {} }
+      { sync: false, syncing: false, loading: false, pathvars: {}, body: {}, data: {} }
     );
 
     store.dispatch(rest.actions.test((err)=> {
       expect(err).to.eql(new Error("Error: Application abort request"));
       expect(store.getState().test).to.eql(
-        { sync: false, syncing: false, loading: true, pathvars:{}, body:{}, data: {} }
+        { sync: false, syncing: false, loading: true, pathvars: {}, body: {}, data: {} }
       );
     }));
 
     expect(store.getState().test).to.eql(
-      { sync: false, syncing: false, loading: true, pathvars:{}, body:{}, data: {}, error: null }
+      { sync: false, syncing: false, loading: true, pathvars: {}, body: {}, data: {}, error: null }
     );
     store.dispatch(rest.actions.test.reset());
 
     expect(store.getState().test).to.eql(
-      { sync: false, syncing: false, loading: false, pathvars:{}, body:{}, data: {} }
+      { sync: false, syncing: false, loading: false, pathvars: {}, body: {}, data: {} }
     );
   });
 
@@ -210,8 +210,8 @@ describe("redux", ()=> {
 
     const store = storeHelper(rest);
     expect(store.getState()).to.eql({
-      external: { sync: false, syncing: false, loading: false, pathvars:{}, body:{}, data: {} },
-      test: { sync: false, syncing: false, loading: false, pathvars:{}, body:{}, data: {} }
+      external: { sync: false, syncing: false, loading: false, pathvars: {}, body: {}, data: {} },
+      test: { sync: false, syncing: false, loading: false, pathvars: {}, body: {}, data: {} }
     });
 
     return new Promise((done)=> {
@@ -228,8 +228,8 @@ describe("redux", ()=> {
           sync: true,
           syncing: false,
           loading: false,
-          pathvars:{},
-          body:{},
+          pathvars: {},
+          body: {},
           data: { url: "/external" },
           error: null
         },
@@ -237,8 +237,8 @@ describe("redux", ()=> {
           sync: false,
           syncing: false,
           loading: false,
-          pathvars:{},
-          body:{},
+          pathvars: {},
+          body: {},
           data: { url: "/external" }
         }
       });
@@ -258,8 +258,8 @@ describe("redux", ()=> {
         sync: true,
         syncing: false,
         loading: false,
-        pathvars:{},
-        body:{},
+        pathvars: {},
+        body: {},
         data: { data: "/api/url" },
         error: null
       });
@@ -268,8 +268,8 @@ describe("redux", ()=> {
         sync: false,
         syncing: false,
         loading: false,
-        pathvars:{},
-        body:{},
+        pathvars: {},
+        body: {},
         data: { data: "/api/url" },
         error: null
       });
@@ -360,8 +360,8 @@ describe("redux", ()=> {
             sync: false,
             syncing: false,
             loading: true,
-            pathvars:{},
-            body:{},
+            pathvars: {},
+            body: {},
             data: {},
             error: null
           }
@@ -371,8 +371,8 @@ describe("redux", ()=> {
             sync: false,
             syncing: false,
             loading: false,
-            pathvars:{},
-            body:{},
+            pathvars: {},
+            body: {},
             data: {}
           }
         }
@@ -383,8 +383,8 @@ describe("redux", ()=> {
             sync: true,
             syncing: false,
             loading: false,
-            pathvars:{},
-            body:{},
+            pathvars: {},
+            body: {},
             data: { data: "/test1" },
             error: null
           }
@@ -394,8 +394,8 @@ describe("redux", ()=> {
             sync: false,
             syncing: false,
             loading: false,
-            pathvars:{},
-            body:{},
+            pathvars: {},
+            body: {},
             data: {}
           }
         }
@@ -406,8 +406,8 @@ describe("redux", ()=> {
             sync: true,
             syncing: false,
             loading: false,
-            pathvars:{},
-            body:{},
+            pathvars: {},
+            body: {},
             data: { data: "/test1" },
             error: null
           }
@@ -417,8 +417,8 @@ describe("redux", ()=> {
             sync: false,
             syncing: false,
             loading: true,
-            pathvars:{},
-            body:{},
+            pathvars: {},
+            body: {},
             data: {},
             error: null
           }
@@ -430,8 +430,8 @@ describe("redux", ()=> {
             sync: true,
             syncing: false,
             loading: false,
-            pathvars:{},
-            body:{},
+            pathvars: {},
+            body: {},
             data: { data: "/test1" },
             error: null
           }
@@ -441,8 +441,8 @@ describe("redux", ()=> {
             sync: true,
             syncing: false,
             loading: false,
-            pathvars:{},
-            body:{},
+            pathvars: {},
+            body: {},
             data: { data: "/test2" },
             error: null
           }
@@ -615,14 +615,13 @@ describe("redux", ()=> {
                 sync: false,
                 syncing: false,
                 loading: false,
-                pathvars:{},
-                body:{},
+                pathvars: {},
+                body: {},
                 data: {},
                 error: err
               });
               resolve();
-            }
-            catch (e) {
+            } catch (e) {
               reject(e);
             }
           }));
@@ -655,8 +654,8 @@ describe("redux", ()=> {
               sync: false,
               syncing: false,
               loading: false,
-              pathvars:{},
-              body:{},
+              pathvars: {},
+              body: {},
               data: {},
               error: err
             });

--- a/test/redux_spec.js
+++ b/test/redux_spec.js
@@ -153,6 +153,8 @@ describe("redux", ()=> {
           sync: false,
           syncing: false,
           loading: false,
+          pathvars:{},
+          body:{},
           data: {},
           error: new Error("Error: Application abort request")
         });
@@ -165,23 +167,23 @@ describe("redux", ()=> {
     store = createStoreWithMiddleware(reducer);
 
     expect(store.getState().test).to.eql(
-      { sync: false, syncing: false, loading: false, data: {} }
+      { sync: false, syncing: false, loading: false, pathvars:{}, body:{}, data: {} }
     );
 
     store.dispatch(rest.actions.test((err)=> {
       expect(err).to.eql(new Error("Error: Application abort request"));
       expect(store.getState().test).to.eql(
-        { sync: false, syncing: false, loading: true, data: {} }
+        { sync: false, syncing: false, loading: true, pathvars:{}, body:{}, data: {} }
       );
     }));
 
     expect(store.getState().test).to.eql(
-      { sync: false, syncing: false, loading: true, data: {}, error: null }
+      { sync: false, syncing: false, loading: true, pathvars:{}, body:{}, data: {}, error: null }
     );
     store.dispatch(rest.actions.test.reset());
 
     expect(store.getState().test).to.eql(
-      { sync: false, syncing: false, loading: false, data: {} }
+      { sync: false, syncing: false, loading: false, pathvars:{}, body:{}, data: {} }
     );
   });
 
@@ -208,8 +210,8 @@ describe("redux", ()=> {
 
     const store = storeHelper(rest);
     expect(store.getState()).to.eql({
-      external: { sync: false, syncing: false, loading: false, data: {} },
-      test: { sync: false, syncing: false, loading: false, data: {} }
+      external: { sync: false, syncing: false, loading: false, pathvars:{}, body:{}, data: {} },
+      test: { sync: false, syncing: false, loading: false, pathvars:{}, body:{}, data: {} }
     });
 
     return new Promise((done)=> {
@@ -226,6 +228,8 @@ describe("redux", ()=> {
           sync: true,
           syncing: false,
           loading: false,
+          pathvars:{},
+          body:{},
           data: { url: "/external" },
           error: null
         },
@@ -233,6 +237,8 @@ describe("redux", ()=> {
           sync: false,
           syncing: false,
           loading: false,
+          pathvars:{},
+          body:{},
           data: { url: "/external" }
         }
       });
@@ -252,6 +258,8 @@ describe("redux", ()=> {
         sync: true,
         syncing: false,
         loading: false,
+        pathvars:{},
+        body:{},
         data: { data: "/api/url" },
         error: null
       });
@@ -260,6 +268,8 @@ describe("redux", ()=> {
         sync: false,
         syncing: false,
         loading: false,
+        pathvars:{},
+        body:{},
         data: { data: "/api/url" },
         error: null
       });
@@ -350,6 +360,8 @@ describe("redux", ()=> {
             sync: false,
             syncing: false,
             loading: true,
+            pathvars:{},
+            body:{},
             data: {},
             error: null
           }
@@ -359,6 +371,8 @@ describe("redux", ()=> {
             sync: false,
             syncing: false,
             loading: false,
+            pathvars:{},
+            body:{},
             data: {}
           }
         }
@@ -369,6 +383,8 @@ describe("redux", ()=> {
             sync: true,
             syncing: false,
             loading: false,
+            pathvars:{},
+            body:{},
             data: { data: "/test1" },
             error: null
           }
@@ -378,6 +394,8 @@ describe("redux", ()=> {
             sync: false,
             syncing: false,
             loading: false,
+            pathvars:{},
+            body:{},
             data: {}
           }
         }
@@ -385,20 +403,24 @@ describe("redux", ()=> {
       ["@@redux-api@r2test", {
         r1: {
           test: {
-            data: { data: "/test1" },
-            error: null,
-            loading: false,
             sync: true,
-            syncing: false
+            syncing: false,
+            loading: false,
+            pathvars:{},
+            body:{},
+            data: { data: "/test1" },
+            error: null
           }
         },
         r2: {
           test: {
-            data: {},
-            error: null,
-            loading: true,
             sync: false,
-            syncing: false
+            syncing: false,
+            loading: true,
+            pathvars:{},
+            body:{},
+            data: {},
+            error: null
           }
         }
       }],
@@ -408,6 +430,8 @@ describe("redux", ()=> {
             sync: true,
             syncing: false,
             loading: false,
+            pathvars:{},
+            body:{},
             data: { data: "/test1" },
             error: null
           }
@@ -417,6 +441,8 @@ describe("redux", ()=> {
             sync: true,
             syncing: false,
             loading: false,
+            pathvars:{},
+            body:{},
             data: { data: "/test2" },
             error: null
           }
@@ -581,17 +607,24 @@ describe("redux", ()=> {
     const ret1 = new Promise((resolve, reject)=>
       store.dispatch(rest.actions.test())
         .then(
-          ()=> reject("Abort shout generate error"),
+          ()=> reject("Abort should generate error"),
           (err)=> {
-            expect(err.message).to.eql("Application abort request");
-            expect(store.getState().test).to.eql({
-              sync: false,
-              syncing: false,
-              loading: false,
-              data: {},
-              error: err
-            });
-            resolve();
+            try {
+              expect(err.message).to.eql("Application abort request");
+              expect(store.getState().test).to.eql({
+                sync: false,
+                syncing: false,
+                loading: false,
+                pathvars:{},
+                body:{},
+                data: {},
+                error: err
+              });
+              resolve();
+            }
+            catch (e) {
+              reject(e);
+            }
           }));
 
     store.dispatch(rest.actions.test.abort());
@@ -622,6 +655,8 @@ describe("redux", ()=> {
               sync: false,
               syncing: false,
               loading: false,
+              pathvars:{},
+              body:{},
               data: {},
               error: err
             });


### PR DESCRIPTION
It would be useful to have the path vars and/or the body of the request in the store. I personnaly use those information to detect if the data needs to be fetched again.

Here is my proposal for such feature.