### PR TITLE
fixed storing of latest request vars

### DIFF
--- a/src/reducerFn.js
+++ b/src/reducerFn.js
@@ -14,12 +14,14 @@ export default function reducerFn(initialState, actions={}, reducer) {
   const { actionFetch, actionSuccess, actionFail,
     actionReset, actionCache, actionAbort } = actions;
   return (state=initialState, action)=> {
-    const params = action.params || {};
+    const request = action.request || {};
+    const params = request.params || {};
+
     switch (action.type) {
       case actionFetch:
         return {
           ...state,
-          pathvars: action.pathvars || {},
+          pathvars: request.pathvars || {},
           body: params.body || {},
           loading: true,
           error: null,

--- a/test/reducerFn_spec.js
+++ b/test/reducerFn_spec.js
@@ -53,7 +53,7 @@ describe("reducerFn", function() {
     };
     const fn = reducerFn(initialState, actions);
 
-    const res1 = fn(initialState, { type: actions.actionFetch, pathvars: { id: 42 } });
+    const res1 = fn(initialState, { type: actions.actionFetch, request: { pathvars: { id: 42 } } });
     expect(res1).to.eql({
       loading: true, error: null, data: { msg: "Hello" }, syncing: false, pathvars: { id: 42 }, body: {}
     });
@@ -91,7 +91,7 @@ describe("reducerFn", function() {
     };
     const fn = reducerFn(initialState, actions);
 
-    const res1 = fn(initialState, { type: actions.actionFetch, pathvars: { other: "var" }, params: { method: "post", body: { hello: "world", it: { should: { store: " the body" } } } } });
+    const res1 = fn(initialState, { type: actions.actionFetch, request: { pathvars: { other: "var" }, params: { method: "post", body: { hello: "world", it: { should: { store: " the body" } } } } } });
     expect(res1).to.eql({
       loading: true, error: null, data: { msg: "Hello" }, syncing: false, pathvars: { other: "var" }, body: { hello: "world", it: { should: { store: " the body" } } }
     });


### PR DESCRIPTION
As mentioned in #152 this will now work with the provided methods.

I would advises against using mocked actions in reducer tests. You are not really testing anything with this and as this example shows you are producing false positives. The problem is that the actual action creators are hidden within actionFn file and finding the correct format of an action requires some searching.

So future work might include:
1. at least extract the action creators so that the format is easy to look up 
2. skip unit testing of state machines and rather use integration testing of actions and reducers
3. enforce some max-len style rules