### PR TITLE
GH-177: Return json object with error

### DIFF
--- a/src/adapters/fetch.js
+++ b/src/adapters/fetch.js
@@ -23,8 +23,11 @@ export default function (fetch) {
     toJSON(resp).then((data)=> {
       if (resp.status >= 200 && resp.status < 300) {
         return data;
+      } else if (resp.status >= 400) {
+        return Promise.reject({ status: resp.status, statusText: resp.statusText });
       } else {
         return Promise.reject(data);
       }
-    }));
+    })
+  );
 }

--- a/src/adapters/fetch.js
+++ b/src/adapters/fetch.js
@@ -19,15 +19,19 @@ function toJSON(resp) {
 }
 
 export default function (fetch) {
-  return (url, opts)=> fetch(url, opts).then(resp=>
-    toJSON(resp).then((data)=> {
-      if (resp.status >= 200 && resp.status < 300) {
-        return data;
-      } else if (resp.status >= 400) {
-        return Promise.reject({ status: resp.status, statusText: resp.statusText });
-      } else {
-        return Promise.reject(data);
-      }
-    })
+  return (url, opts)=> fetch(url, opts).then((resp)=> {
+    if (resp.status >= 400) {
+      return Promise.reject({ status: resp.status, statusText: resp.statusText });
+    } else {
+      return toJSON(resp).then((data)=> {
+        if (resp.status >= 200 && resp.status < 300) {
+          return data;
+        } else {
+          return Promise.reject(data);
+        }
+      });
+    }
+  }
+
   );
 }

--- a/test/adapters_fetch_spec.js
+++ b/test/adapters_fetch_spec.js
@@ -24,4 +24,18 @@ describe("fetch adapters", function() {
         expect(jsonCall).to.eql(1);
       });
   });
+  it("should return the error response as content", function() {
+    const fetchApi = (url, opts)=> new Promise((resolve)=> {
+      expect(url).to.eql("url");
+      expect(opts).to.eql("opts");
+      resolve({
+        status: 404,
+        statusText: "Not Found",
+      });
+    });
+    return fetch(fetchApi)("url", "opts")
+      .catch((error)=> {
+        expect(error).to.eql({ status: 404, statusText: "Not Found" });
+      });
+  });
 });


### PR DESCRIPTION
Currently, there is not information what it was the problem using response information provided by fetch API.

The data provided initially will be the status code and text from the response.

Fix #177 