### PR TITLE
normalize IE9 1223 response to 204 no content

### DIFF
--- a/src/adapters/fetch.js
+++ b/src/adapters/fetch.js
@@ -20,18 +20,20 @@ function toJSON(resp) {
 
 export default function (fetch) {
   return (url, opts)=> fetch(url, opts).then((resp)=> {
-    if (resp.status >= 400) {
-      return Promise.reject({ status: resp.status, statusText: resp.statusText });
+    // Normalize IE9's response to HTTP 204 when Win error 1223.
+    const status = (resp.status === 1223) ? 204 : resp.status;
+    const statusText = (resp.status === 1223) ? "No Content" : resp.statusText;
+
+    if (status >= 400) {
+      return Promise.reject({ status, statusText });
     } else {
       return toJSON(resp).then((data)=> {
-        if (resp.status >= 200 && resp.status < 300) {
+        if (status >= 200 && status < 300) {
           return data;
         } else {
           return Promise.reject(data);
         }
       });
     }
-  }
-
-  );
+  });
 }

--- a/test/adapters_fetch_spec.js
+++ b/test/adapters_fetch_spec.js
@@ -2,7 +2,7 @@
 
 /* global describe, it */
 /* eslint import/no-extraneous-dependencies: ["error", {"devDependencies": true}] */
-import { expect } from "chai";
+import { expect, assert } from "chai";
 import fetch from "../src/adapters/fetch";
 
 describe("fetch adapters", function() {
@@ -36,6 +36,30 @@ describe("fetch adapters", function() {
     return fetch(fetchApi)("url", "opts")
       .catch((error)=> {
         expect(error).to.eql({ status: 404, statusText: "Not Found" });
+      });
+  });
+  // Sometimes IE9 translates HTTP 204 (No Content)
+  // into its own internal Status Code 1223.
+  // redux-api rightly treats this an error unless
+  // the status is coerced into 204 No Content
+  it("should normalise IE9 1223 response into 204 No Content ", ()=> {
+    const fetchApi = (url, opts)=> new Promise((resolve)=> {
+      expect(url).to.eql("url");
+      expect(opts).to.eql("opts");
+      resolve({
+        status: 1223,
+        text() {
+          return Promise.resolve();
+        }
+      });
+    });
+
+    return fetch(fetchApi)("url", "opts")
+      .then(()=> {
+        assert.isOk(true, "response status 1223 normalised");
+      })
+      .catch(()=> {
+        assert.isNotOk("response status 1223 not normalized");
       });
   });
 });


### PR DESCRIPTION
PR to tackle #189 where IE9 sometimes returns status code 1223 instead of HTTP 204 No Content.

Usually when responding to a PUT request.

The PR changes fetch adapter to coerces HTTP 1223 into 204 No Content.